### PR TITLE
Provide fallback for TMPDIR

### DIFF
--- a/R/callback.R
+++ b/R/callback.R
@@ -113,7 +113,7 @@ check_callback <- function() {
 
     ## Replace long file names on OSX, they look bad
     if (grepl("\u2018.*\u2019", x)) {
-      tmpdir <- Sys.getenv("TMPDIR")
+      tmpdir <- Sys.getenv("TMPDIR", unset="/tmp")
       x <- sub(paste0("\u2018", tmpdir), "\u2018$TMPDIR/", x, fixed = TRUE)
       x <- sub(paste0("\u2018/private", tmpdir), "\u2018$TMPDIR/", x, fixed = TRUE)
     }


### PR DESCRIPTION
When I run `rcmdcheck` on a Debian/Ubuntu system, the output shows `$TMPDIR` is a few places.  I am not quite sure yet where all of them come from but one fix is suggested here --- we tend to not have an environment variable TMPDIR (or at least I don't when I run littler calling `rcmdcheck`).